### PR TITLE
Fix/selftests

### DIFF
--- a/Core/Inc/top_board/oled/self_tests/system_test.h
+++ b/Core/Inc/top_board/oled/self_tests/system_test.h
@@ -9,5 +9,6 @@ void system_test_init(page_struct *parent);
 void system_test_run();
 uint32_t get_system_test_time_started();
 bool get_system_test_running();
+void system_test_reset();
 
 #endif /* INC_SYSTEM_TEST_H_ */

--- a/Core/Inc/top_board/robot.h
+++ b/Core/Inc/top_board/robot.h
@@ -61,6 +61,7 @@ extern uint64_t unix_timestamp;
 extern bool DISABLE_BUZZER;
 extern bool TEST_MODE;
 extern bool flag_PowerBoard_alive, flag_DribblerBoard_alive, flag_KickerBoard_alive;
+extern REM_RobotCommand activeRobotCommand;
 
 //headers outgoing packets
 extern CAN_TxHeaderTypeDef areYouAliveHeaderToPower ;

--- a/Core/Src/top_board/oled/menus/main_menu.c
+++ b/Core/Src/top_board/oled/menus/main_menu.c
@@ -30,7 +30,6 @@ void main_menu_initChildren(page_struct *parent) {
     strcpy(drain_battery_menu.page_name, "Drain battery");
     drain_battery_menu.parent = parent;
     drain_battery_menu.is_menu = true;
-    drain_battery_menu.is_test = BLOCKING_TEST;
     add_child_to_parent(&drain_battery_menu);
     drain_battery_initChildren(&drain_battery_menu);
 }

--- a/Core/Src/top_board/oled/self_tests/drain_battery.c
+++ b/Core/Src/top_board/oled/self_tests/drain_battery.c
@@ -68,17 +68,19 @@ void drain_battery_run(float target) {
         SSD1306_Puts("doable\" works", &Font_7x10, 1);
         SSD1306_UpdateScreen();
         DRAIN_BATTERY = false;
-    } else if (target == 18.0f || target > powerVoltage.voltagePowerBoard) {
+    } else if (target == 18.0f || target <= powerVoltage.voltagePowerBoard) {
         DRAIN_BATTERY = true;
     } else {
-        DRAIN_BATTERY = true;
+        DRAIN_BATTERY = false;
         end_of_test();
     }
 }
 
 void drain_battery_update_screen(page_struct *p) {
-    strcpy(p->line0, "Current voltage");
-    char temp[MAX_STRING_LENGTH];
-    sprintf(temp, "%fV", powerVoltage.voltagePowerBoard);
-    strcpy(p->line1, temp);    
+    if (DRAIN_BATTERY) {
+        strcpy(p->line0, "Current voltage");
+        char temp[MAX_STRING_LENGTH];
+        sprintf(temp, "%fV", powerVoltage.voltagePowerBoard);
+        strcpy(p->line1, temp);
+    }    
 }

--- a/Core/Src/top_board/oled/self_tests/system_test.c
+++ b/Core/Src/top_board/oled/self_tests/system_test.c
@@ -41,4 +41,8 @@ bool get_system_test_running() {
     return system_test_running;
 }
 
+void system_test_reset() {
+    system_test_running = false;
+}
+
 

--- a/Core/Src/top_board/oled/self_tests/wheel_twitch.c
+++ b/Core/Src/top_board/oled/self_tests/wheel_twitch.c
@@ -17,6 +17,10 @@ void wheel_twitch_init(page_struct *parent) {
     strcpy(wheel_twitch_warning.page_name, "Wheel twitch");
     wheel_twitch_warning.parent = parent;
     wheel_twitch_warning.is_test = BLOCKING_TEST;
+    strcpy(wheel_twitch_warning.line0, "Make sure that");
+    strcpy(wheel_twitch_warning.line1, "the wheels are");
+    strcpy(wheel_twitch_warning.line2, "off the ground!");
+    strcpy(wheel_twitch_warning.line3, "OK to continue");
     add_child_to_parent(&wheel_twitch_warning);
     //running test
     pages_set_default_values(&wheel_twitch_running);

--- a/Core/Src/top_board/peripherals/OLED_driver.c
+++ b/Core/Src/top_board/peripherals/OLED_driver.c
@@ -153,8 +153,12 @@ void OLED_set_error_too_many_children(char* page_name) {
 void start_of_test() {
     clear_screen();
     putPageName();
-    SSD1306_GotoXY (5,20);
-    SSD1306_Puts("Test is running", &Font_7x10, 1);
+    strcpy(current_page->line0, "Test is running");
+    strcpy(current_page->line1, "");
+    strcpy(current_page->line2, "");
+    strcpy(current_page->line3, "");
+    strcpy(current_page->line3, "");
+    display_text();
     SSD1306_UpdateScreen();   
 }
 
@@ -165,12 +169,12 @@ void end_of_test() {
     test_is_finished = true;
     clear_screen();
     putPageName();
-    SSD1306_GotoXY (5,20);
-    SSD1306_Puts("Test done!", &Font_7x10, 1);
-    SSD1306_GotoXY (5,31);
-    SSD1306_Puts("press \"OK\" to", &Font_7x10, 1);
-    SSD1306_GotoXY (5,42);
-    SSD1306_Puts("continue", &Font_7x10, 1);
+    strcpy(current_page->line0, "Test is running");
+    strcpy(current_page->line1, "Test done!");
+    strcpy(current_page->line2, "press \"OK\" to");
+    strcpy(current_page->line3, "continue");
+    strcpy(current_page->line3, "");
+    display_text();
     SSD1306_UpdateScreen();   
 }
 

--- a/Core/Src/top_board/peripherals/OLED_driver.c
+++ b/Core/Src/top_board/peripherals/OLED_driver.c
@@ -163,10 +163,18 @@ void start_of_test() {
 }
 
 /**
- * @brief display that the test has ended
+ * @brief display that the test has ended; brake wheels and other safety
 */
 void end_of_test() {
+    //safety
     test_is_finished = true;
+    wheels_Brake();
+    activeRobotCommand.doKick = false;
+    activeRobotCommand.doChip = false;
+    activeRobotCommand.kickAtAngle = false;
+    activeRobotCommand.dribbler = 0;
+    activeRobotCommand.angularVelocity = 0;
+    //screen
     clear_screen();
     putPageName();
     strcpy(current_page->line0, "Test is running");
@@ -175,8 +183,7 @@ void end_of_test() {
     strcpy(current_page->line3, "continue");
     strcpy(current_page->line3, "");
     display_text();
-    wheels_Brake();
-    SSD1306_UpdateScreen();   
+    SSD1306_UpdateScreen();
 }
 
 /**
@@ -228,6 +235,7 @@ static void onButtonPressMenu(button_id_t button) {
 static void onButtonPressSelfTest(button_id_t button) {
     if (current_page->n_of_childeren == 0 || button != BUTTON_OK) {
         //move up until back in a menu
+        end_of_test();
         while(!current_page->is_menu) {
             current_page = current_page->parent;
         }

--- a/Core/Src/top_board/peripherals/OLED_driver.c
+++ b/Core/Src/top_board/peripherals/OLED_driver.c
@@ -175,6 +175,7 @@ void end_of_test() {
     strcpy(current_page->line3, "continue");
     strcpy(current_page->line3, "");
     display_text();
+    wheels_Brake();
     SSD1306_UpdateScreen();   
 }
 

--- a/Core/Src/top_board/robot.c
+++ b/Core/Src/top_board/robot.c
@@ -955,7 +955,7 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
     uint32_t current_time = HAL_GetTick();
     if(htim->Instance == TIM_CONTROL->Instance) {
-		if(!ROBOT_INITIALIZED) return;
+		if(!ROBOT_INITIALIZED || OLED_get_current_page_test_type() == BLOCKING_TEST) return;
 
 		if (!unix_initalized && activeRobotCommand.timestamp != 0){
 			unix_timestamp = activeRobotCommand.timestamp;

--- a/Core/Src/top_board/robot.c
+++ b/Core/Src/top_board/robot.c
@@ -1009,16 +1009,13 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
 		float* pointerGlobalBodyRef;
 		pointerGlobalBodyRef = stateControl_GetBodyGlobalRef();
 
-		if (!TEST_MODE || OLED_get_current_page_test_type() != NON_BLOCKING_TEST) {
+		if (!TEST_MODE || OLED_get_current_page_test_type() == NON_BLOCKING_TEST) {
 		
 			wheels_set_command_speed( stateControl_GetWheelRef() );
 
 			// In order to drain the battery as fast as possible we instruct the wheels to go their maximum possible speeds.
 			// However, for the sake of safety we make sure that if the robot actually turns it immediately stops doing this, since you
 			// only want to execute this on a roll of tape.
-			//
-			// TODO: Once the battery meter has been implemented in software, it would perhaps be nice to stop the drainaige at programmable level.
-			//       Currently you are stuck on the automated shutdown value that is controlled by the powerboard.
 			if(DRAIN_BATTERY){
 
 				// TODO Instruct each wheel to go 30 rad/s

--- a/Core/Src/top_board/robot.c
+++ b/Core/Src/top_board/robot.c
@@ -725,8 +725,14 @@ void loop(void){
         while (heartbeat_17ms < current_time) heartbeat_17ms += 17;
 
         if(system_test_running){
-            updateTestCommand(&activeRobotCommand, current_time - timestamp_initialized);
-            flag_sdcard_write_command = true;
+			// Test is running fine
+			if (OLED_get_current_page_test_type() == NON_BLOCKING_TEST) {
+				updateTestCommand(&activeRobotCommand, current_time - timestamp_initialized);
+				flag_sdcard_write_command = true;
+			} else { 
+				// Test ended early so reset
+				system_test_reset();
+			}
         }
 
 		if (TEST_MODE) {


### PR DESCRIPTION
1. Display warning for wheel twitch
2. Fixed drain battery display when test ended by movement
3. Fixed drain battery running ending early
4. Fixed drain battery bug where sign was flipped
5. Added more safety for tests ending early
6. Fixed displaying issue with system test ending early